### PR TITLE
FIX: ignoring return value of ‘fread’

### DIFF
--- a/test_yuv_rgb.c
+++ b/test_yuv_rgb.c
@@ -41,8 +41,11 @@ int readRawYUV(const char *filename, uint32_t width, uint32_t height, uint8_t **
 	fseek(fp, 0, SEEK_SET);
 	
 	*YUV = malloc(size);
-	fread(*YUV, 1, size, fp);
-	
+	size_t result = fread(*YUV, 1, size, fp);
+	if (result != lSize) {
+		fputs ("Reading error", stderr);
+		return 3;
+	}
 	return 0;
 }
 

--- a/test_yuv_rgb.c
+++ b/test_yuv_rgb.c
@@ -42,7 +42,7 @@ int readRawYUV(const char *filename, uint32_t width, uint32_t height, uint8_t **
 	
 	*YUV = malloc(size);
 	size_t result = fread(*YUV, 1, size, fp);
-	if (result != lSize) {
+	if (result != size) {
 		fputs ("Reading error", stderr);
 		return 3;
 	}

--- a/test_yuv_rgb.c
+++ b/test_yuv_rgb.c
@@ -46,6 +46,7 @@ int readRawYUV(const char *filename, uint32_t width, uint32_t height, uint8_t **
 		fputs ("Reading error", stderr);
 		return 3;
 	}
+	fclose(fp);
 	return 0;
 }
 


### PR DESCRIPTION
fix ignoring return value of ‘fread’ error(Linux).