### PR TITLE
Add MSVC compiler support

### DIFF
--- a/test_yuv_rgb.c
+++ b/test_yuv_rgb.c
@@ -11,7 +11,11 @@
 #include <string.h>
 #include <time.h>
 
+#ifdef _MSC_VER
+#include <emmintrin.h>
+#else
 #include <x86intrin.h>
+#endif
 
 #if USE_FFMPEG
 #include <libswscale/swscale.h>

--- a/yuv_rgb.c
+++ b/yuv_rgb.c
@@ -3,9 +3,25 @@
 
 #include "yuv_rgb.h"
 
+#ifdef _MSC_VER
+#include <emmintrin.h>
+#else
 #include <x86intrin.h>
+#endif
 
 #include <stdio.h>
+
+#ifdef _MSC_VER
+// MSVC does not have __SSE2__ macro
+#if (defined(_M_AMD64) || defined(_M_X64) || (_M_IX86_FP == 2))
+#define _YUVRGB_SSE2_ 
+#endif
+#else
+// For else than MSVC
+#ifdef __SSE2__
+#define _YUVRGB_SSE2_ 
+#endif // __SSE2__
+#endif // _MSC_VER
 
 
 uint8_t clamp(int16_t value)
@@ -429,7 +445,7 @@ void nv21_rgb24_std(
 }
 
 
-#ifdef __SSE2__
+#ifdef _YUVRGB_SSE2_
 
 //see rgb.txt
 #define UNPACK_RGB24_32_STEP(RS1, RS2, RS3, RS4, RS5, RS6, RD1, RD2, RD3, RD4, RD5, RD6) \
@@ -915,7 +931,7 @@ void rgb32_yuv420_sseu(uint32_t width, uint32_t height,
 
 #endif
 
-#ifdef __SSE2__
+#ifdef _YUVRGB_SSE2_
 
 #define UV2RGB_16(U,V,R1,G1,B1,R2,G2,B2) \
 	r_tmp = _mm_srai_epi16(_mm_mullo_epi16(V, _mm_set1_epi16(param->cr_factor)), 6); \
@@ -1300,4 +1316,4 @@ void nv21_rgb24_sseu(
 
 
 
-#endif //__SSE2__
+#endif // _YUVRGB_SSE2_


### PR DESCRIPTION
Hi, your conversion functions was good, but it can't be compiled under Microsoft Visual C++ compilers. Fortunately, the workarounds seems trivial and no codes other than macro and include declarations was changed.

* For include, MSVC doesn't have `x86intrin.h` header but it has `emmintrin.h` for same exact things. 
* For SSE2 detection, MSVC also doesn't have `__SSE2__` macro, but I use platform detection instead like `_M_IX86_FP` for 32bit as [documentation](https://docs.microsoft.com/en-us/cpp/preprocessor/predefined-macros?redirectedfrom=MSDN&view=vs-2019#microsoft-specific-predefined-macros) and defaults if 64bit compiler was used. Also use `_YUVRGB_SSE2_` macro for SSE2 compiler detection support rather than directly use `__SSE2__` because of that.

At least, It works for me under MSVC 2015 although needs for more testing.